### PR TITLE
Modify team page thumbnail image sizes

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -169,6 +169,7 @@ require get_template_directory() . '/inc/jetpack.php';
 require get_template_directory() . '/inc/widgets.php';
 
 /**
- * Define big thumbnail size for the Team Members page
+ * Define big thumbnail sizes for the Team Members page
  */
-add_image_size( 'custom-team-member-big' , 430, 286, true );
+add_image_size( 'custom-team-member-landscape' , 430, 286, true );
+add_image_size( 'custom-team-member-portrait', 200, 300, true );


### PR DESCRIPTION
The 2017 team photos were done in portrait mode, so we need to define a new thumbnail size for the images on the team members page. This commit introduces a new `custom-team-member-portrait` image size and renames last year's image size to `custom-team-member-landscape`.